### PR TITLE
Make sure API key gets added to session header

### DIFF
--- a/teable/core/http.py
+++ b/teable/core/http.py
@@ -60,11 +60,11 @@ class TeableHttpClient:
             )
         
         self.session = requests.Session()
-        if api_key:
+        if self.config.api_key:
             self.session.headers.update({
-                'Authorization': f'Bearer {api_key}'
+                'Authorization': f'Bearer {self.config.api_key}'
             })
-            
+
         self._rate_limit = None
         self._rate_limit_remaining = None
         self._rate_limit_reset = None


### PR DESCRIPTION
I admit that I may be missing something but I think currently the API key is not added to the session's header when `TeableHttpClient` is initialized with a `TeableConfig` - which is what `TeableClient` is doing. 

This PR makes sure the header is updated correctly.